### PR TITLE
Adding fallback middleware property so that library is compatible wit…

### DIFF
--- a/src/middleware.factory.js
+++ b/src/middleware.factory.js
@@ -66,13 +66,23 @@ function middlewareFactory($injector, $q) {
 	};
 
 	/**
+	 * Gets the route middleware property
+	 * @param {object} toRoute
+	 * @returns {array|string}
+   */
+	function getRouteMiddleware(route) {
+		return route.middleware || ((route.data || {}).vars || {}).middleware;
+	}
+
+	/**
 	 * Determine if the given route has middleware
 	 *
 	 * @param {object} toRoute
 	 * @returns {boolean}
 	 */
 	function hasMiddleware(route) {
-		return !!route.middleware && !!route.middleware.length;
+		var middleware = getRouteMiddleware(route);
+		return !!middleware && !!middleware.length;
 	}
 
 	/**
@@ -83,12 +93,13 @@ function middlewareFactory($injector, $q) {
 	 * @returns {array}
 	 */
 	function getMiddlewareNames(route) {
+		var middleware = getRouteMiddleware(route);
 		// Return the middleware names as an array
-		return route.middleware instanceof Array
-			? route.middleware
-			: typeof route.middleware === 'undefined'
+		return middleware instanceof Array
+			? middleware
+			: typeof middleware === 'undefined'
 				? []
-				: route.middleware.split('|');
+				: middleware.split('|');
 	}
 
 	/**


### PR DESCRIPTION
Adding fallback middleware property so that library is compatible with foundation-apps dynamic routing.

I would very much like to use this library with foundation-apps.  They use a convenient dynamic routing that allows states to be defined as a header in the html template.

However, the state definition passes data through the custom data parameter ( see:  https://github.com/zurb/foundation-apps/blob/master/js/angular/services/foundation.dynamicRouting.js && https://github.com/angular-ui/ui-router/wiki ).  Specifically, in a vars object.

It would be great if this library handled the fallback and I would very much appreciate being able to use it.
